### PR TITLE
fix for process not exiting when running on Sonoma

### DIFF
--- a/TodayView.m
+++ b/TodayView.m
@@ -17,6 +17,15 @@ static NSString * const MyModuleName = @"com.gingerbeardman.today";
 - (id)initWithFrame:(NSRect)frame isPreview:(BOOL)isPreview
 {
     self = [super initWithFrame:frame isPreview:isPreview];
+    if (!isPreview) {
+      [[NSDistributedNotificationCenter defaultCenter]
+          addObserverForName: @"com.apple.screensaver.willstop"
+                      object: nil
+                       queue: nil
+                  usingBlock:^(NSNotification *n) {
+          [[NSApplication sharedApplication] terminate: self];
+        }];
+    }
     if (self) {
 		ScreenSaverDefaults *defaults;
 		defaults = [ScreenSaverDefaults defaultsForModuleWithName:MyModuleName];


### PR DESCRIPTION
As detailed in [this post](https://www.jwz.org/blog/2023/10/xscreensaver-6-08-out-now/) and [this other post](https://zsmb.co/building-a-macos-screen-saver-in-kotlin/#macos-sonoma), legacy screen savers on macOS Sonoma will continue running in the background even after the screen saver stops running. I've tested on my M3 Mac that with this change, the process now exits properly. 